### PR TITLE
I32-remove-admin-type

### DIFF
--- a/tool/management/commands/email_attendances.py
+++ b/tool/management/commands/email_attendances.py
@@ -23,11 +23,6 @@ class Command(BaseCommand):
                             dest='staff',
                             help='Report attendance to staff')
 
-        parser.add_argument('--admins',
-                            action='store_true',
-                            dest='admins',
-                            help='Report attendance to admins')
-
         parser.add_argument('--all-users',
                             action='store_true',
                             dest='all-users',
@@ -61,8 +56,6 @@ class Command(BaseCommand):
             users = Student.objects.all()
         elif options['staff']:
             users = Staff.objects.all()
-        elif options['admins']:
-            users = User.objects.filter(is_staff=True)
         else:
             self.stdout.write(self.style.NOTICE('No users argument supplied. Use --help to get command options'))
             return
@@ -127,13 +120,8 @@ def email_attendance_report(self, user, time_period, connection, test_only, to_d
             pass
 
     if not user_type_found:
-        # finally check if admin user
-        if user.is_staff:
-            email_details = get_admin_attendance_report(self, time_period, to_date)
-            email_details.is_student = False
-        else:
-            self.stdout.write(self.style.NOTICE('Couldn\'t determine user type for: ' + user.username + '. Skipping'))
-            return
+        self.stdout.write(self.style.NOTICE('Couldn\'t determine user type for: ' + user.username + '. Skipping'))
+        return
 
     # if no attendance data for email, don't send it
     if not email_details.modules:
@@ -153,12 +141,6 @@ def get_student_attendance_report(self, student, time_period, to_date):
 
 def get_staff_attendance_report(self, lecturer, time_period, to_date):
     modules = lecturer.modules.all()
-    return get_email_details(self, time_period, modules, to_date, None)
-
-
-def get_admin_attendance_report(self, time_period, to_date):
-    # for admins, get everything
-    modules = Module.objects.all()
     return get_email_details(self, time_period, modules, to_date, None)
 
 

--- a/tool/templates/tool/index.html
+++ b/tool/templates/tool/index.html
@@ -159,8 +159,6 @@
   <br>
   <hr>
   <br>
-{% elif user_type and user_type == "ADMIN" %}
-  <p>No lecturers are available.</p>
 {% endif %}
   
 <!-- STUDENTS -->
@@ -219,7 +217,7 @@
   <p>No lectures are available.</p>
 {% endif %}
   
-{% if user.is_staff %}
+{% if user_type and user_type == "STAFF" %}
   <hr>
   <h3>Admin Panel</h3>
   <h4>Upload Marks</h4>

--- a/tool/templates/tool/settings/settings.html
+++ b/tool/templates/tool/settings/settings.html
@@ -104,9 +104,7 @@
 <h2>Account</h2>
 <a class="setting" href="{% url 'tool:password_change' %}">Change Password</a>
 
-{% if user_type %}
-{% if user_type == "STAFF" or user_type == "ADMIN" %}
-
+{% if user_type and user_type == "STAFF" %}
 <hr>
 
 <h2>Admin</h2>
@@ -117,6 +115,5 @@
 <a class="setting" href="{% url 'tool:admin_create_student' %}">Create Student</a>
 <br>
 <a class="setting" href="{% url 'tool:admin_create_staff' %}">Create Staff</a>
-{% endif %}
 {% endif %}
 {% endblock %}

--- a/tool/tests/tests_auth.py
+++ b/tool/tests/tests_auth.py
@@ -1,27 +1,32 @@
-from django.contrib.auth.models import User
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
 
+from tool.tests.utils import TestUtils
+
 
 class AuthTests(TestCase):
     def test_login_valid_credentials(self):
-        User.objects.create_superuser('john', 'test@mail.com', 'johnpassword')
-        test_login(self, 'john', 'johnpassword', True)
+        TestUtils.create_student('jill')
+        test_login(self, 'jill', '12345', True)
 
     def test_login_invalid_credentials(self):
-        User.objects.create_superuser('john', 'test@mail.com', 'johnpassword')
-        test_login(self, 'john', 'wrongpassword', False)
+        TestUtils.create_student('jill')
+        test_login(self, 'jill', 'wrongpassword', False)
 
     def test_login_nonexistent_user(self):
         test_login(self, 'nouser', 'nopassword', False)
 
     def test_password_reset_recognised_email(self):
-        User.objects.create_user('john', 'test@mail.com', 'johnpassword')
+        user = TestUtils.create_student('jill').user
+        user.email = 'test@mail.com'
+        user.save()
         test_password_reset(self, 'test@mail.com', True)
 
     def test_password_reset_unrecognised_email(self):
-        User.objects.create_user('john', 'test@mail.com', 'johnpassword')
+        user = TestUtils.create_student('jill').user
+        user.email = 'test@mail.com'
+        user.save()
         test_password_reset(self, 'different@mail.com', False)
 
 

--- a/tool/tests/tests_download.py
+++ b/tool/tests/tests_download.py
@@ -8,13 +8,13 @@ from .utils import *
 
 class DownloadTests(TestCase):
     def test_download(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         response = test_download(self)
 
         self.assertEquals(response.get('Content-Disposition'), "inline; filename=upload_example.xlsx")
 
     def test_download_nonexistent_file(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         response = self.client.get(reverse('tool:download', kwargs={'path': 'no-exist'}), follow=True)
         self.assertEquals(response.status_code, 404)
 
@@ -23,12 +23,8 @@ class DownloadTests(TestCase):
         TestUtils.authenticate_student(self)
         self.assertEquals(test_download(self).status_code, 403)
 
-        # staff - forbidden
+        # staff is the only allowed user type - should be the only one to successfully download
         TestUtils.authenticate_staff(self)
-        self.assertEquals(test_download(self).status_code, 403)
-
-        # admin is the only allowed user type - should be the only one to successfully download
-        TestUtils.authenticate_admin(self)
         self.assertEquals(test_download(self).status_code, 200)
 
     def test_unauthenticated_upload(self):

--- a/tool/tests/tests_module_course_view_settings.py
+++ b/tool/tests/tests_module_course_view_settings.py
@@ -6,10 +6,6 @@ from .utils import *
 
 class ModuleCourseViewSettingsTests(TestCase):
     def test_user_type_access(self):
-        TestUtils.authenticate_admin(self)
-        test_settings_and_save_pages(self, 404, 404)
-
-        self.client.logout()
         TestUtils.authenticate_student(self)
         test_settings_and_save_pages(self, 404, 404)
 

--- a/tool/tests/tests_single_views.py
+++ b/tool/tests/tests_single_views.py
@@ -5,10 +5,6 @@ from .utils import *
 
 
 class SingleModuleViewTests(TestCase):
-    def test_single_module_view_admin(self):
-        TestUtils.authenticate_admin(self)
-        test_valid_module_view(self)
-
     def test_single_module_view_staff(self):
         TestUtils.authenticate_staff(self)
         test_valid_module_view(self)
@@ -30,7 +26,7 @@ class SingleModuleViewTests(TestCase):
         self.assertRedirects(response, '/tool/login/?next=/tool/modules/10', status_code=302)
 
     def test_nonexistent_module(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         TestUtils.create_module('COM101', 'COM101-crn')
         response = go_to_module(self, 10)
@@ -38,10 +34,6 @@ class SingleModuleViewTests(TestCase):
 
 
 class SingleCourseViewTests(TestCase):
-    def test_single_course_view_admin(self):
-        TestUtils.authenticate_admin(self)
-        test_valid_course_view(self, True)
-
     def test_single_course_view_staff(self):
         TestUtils.authenticate_staff(self)
         test_valid_course_view(self, True)
@@ -70,10 +62,6 @@ class SingleCourseViewTests(TestCase):
 
 
 class SingleLecturerViewTests(TestCase):
-    def test_single_lecturer_view_admin(self):
-        TestUtils.authenticate_admin(self)
-        test_valid_lecturer_view(self, False)
-
     def test_single_lecturer_view_staff(self):
         user = TestUtils.authenticate_staff(self)
         this_lecturer = Staff.objects.get(user=user)
@@ -96,7 +84,7 @@ class SingleLecturerViewTests(TestCase):
         self.assertRedirects(response, '/tool/login/?next=/tool/lecturers/10', status_code=302)
 
     def test_nonexistent_lecturer(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         TestUtils.create_staff('e00123456')
         response = go_to_lecturer(self, 10)
@@ -104,10 +92,6 @@ class SingleLecturerViewTests(TestCase):
 
 
 class SingleStudentViewTests(TestCase):
-    def test_single_student_view_admin(self):
-        TestUtils.authenticate_admin(self)
-        test_valid_student_view(self, False)
-
     def test_single_student_view_staff(self):
         TestUtils.authenticate_staff(self)
         test_valid_student_view(self, False)
@@ -129,7 +113,7 @@ class SingleStudentViewTests(TestCase):
         self.assertRedirects(response, '/tool/login/?next=/tool/students/10', status_code=302)
 
     def test_nonexistent_student(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         TestUtils.create_student('B00123456')
         response = go_to_student(self, 10)
@@ -137,10 +121,6 @@ class SingleStudentViewTests(TestCase):
 
 
 class SingleLectureViewTests(TestCase):
-    def test_single_lecture_view_admin(self):
-        TestUtils.authenticate_admin(self)
-        test_valid_lecture_view(self, False)
-
     def test_single_lecture_view_staff(self):
         TestUtils.authenticate_staff(self)
         test_valid_lecture_view(self, False)
@@ -162,7 +142,7 @@ class SingleLectureViewTests(TestCase):
         self.assertRedirects(response, '/tool/login/?next=/tool/lectures/10', status_code=302)
 
     def test_nonexistent_lecture(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         TestUtils.create_student('B00123456')
         response = go_to_lecture(self, 10)

--- a/tool/tests/tests_upload.py
+++ b/tool/tests/tests_upload.py
@@ -18,7 +18,7 @@ class UploadTests(TestCase):
         test_upload_valid_data(self, 'Attendance_Test_xlsx.xlsx')
 
     def test_sequential_upload_replaces(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         test_upload(self, 'upload_test_valid.csv', 'code_EEE312 crn_EEE312-1', None)
         validate_valid_data(self, False)
@@ -32,13 +32,13 @@ class UploadTests(TestCase):
         validate_valid_data(self, True)
 
     def test_upload_unrecognised_module(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         # uploading valid data but without full DB setup
         test_upload(self, 'upload_test_valid.csv', 'code_EEE312 crn_EEE312-1',
                     'Unrecognised module for upload #1. Please select a module from the list.')
 
     def test_upload_unrecognised_student(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         TestUtils.create_staff('e00123456')
         TestUtils.create_staff('e00987654')
         TestUtils.create_module('EEE312', 'EEE312-1')
@@ -47,24 +47,24 @@ class UploadTests(TestCase):
                     'Error processing file upload_test_valid.csv: Error with inputs: [[Unrecognised student: 10519C]] at line 5')
 
     def test_upload_invalid_attendance_data(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         test_upload(self, 'upload_test_invalid.csv', 'code_EEE312 crn_EEE312-1',
                     'Error processing file upload_test_invalid.csv: Error with inputs: [[Unrecognised attendance value for 10519C: yes at column 4, Unrecognised attendance value for 10519C: no at column 7]] at line 5')
 
     def test_upload_incorrect_file_extension(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         test_upload(self, 'upload_test_wrong_ext.txt', 'code_EEE312 crn_EEE312-1',
                     'Invalid file type for upload #1. Only csv, xls, xlsx files are accepted.')
 
     def test_upload_no_file(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         test_upload(self, None, 'code_EEE312 crn_EEE312-1', 'No file uploaded. Please upload a .csv file.')
 
     def test_upload_multiple_files(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         test_multiple_upload(self, ['upload_test_valid.csv', 'upload_test_valid_2.csv'],
                              ['code_EEE312 crn_EEE312-1', 'code_COM999 crn_COM999-1'],
@@ -73,7 +73,7 @@ class UploadTests(TestCase):
 
     # tests valid and invalid file, and tests that valid file was still uploaded
     def test_upload_multiple_files_invalid(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
         create_db_props()
         self.assertEqual(len(StudentAttendance.objects.all()), 0)
         test_multiple_upload(self, ['upload_test_valid.csv', 'upload_test_invalid.csv'],
@@ -92,13 +92,8 @@ class UploadTests(TestCase):
         test_usertype_upload(self, 403)
         self.assertEqual(get_module_student_count('EEE312'), 0)
 
-        # staff - forbidden
+        # staff is the only allowed user type - should be the only one to successfully upload
         TestUtils.authenticate_staff(self)
-        test_usertype_upload(self, 403)
-        self.assertEqual(get_module_student_count('EEE312'), 0)
-
-        # admin is the only allowed user type - should be the only one to successfully upload
-        TestUtils.authenticate_admin(self)
         test_usertype_upload(self, 200)
         self.assertEqual(get_module_student_count('EEE312'), 2)
 
@@ -113,7 +108,7 @@ class UploadTests(TestCase):
 
 
 def test_upload_valid_data(self, resource_path):
-    TestUtils.authenticate_admin(self)
+    TestUtils.authenticate_staff(self)
     create_db_props()
 
     # initial check that module is not linked to student

--- a/tool/tests/tests_views.py
+++ b/tool/tests/tests_views.py
@@ -14,7 +14,7 @@ class ViewsTests(TestCase):
         self.assertNotContains(response, 'Please login to see this page.')
 
     def test_login_redirects_if_authenticated(self):
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         url = reverse('tool:login')
         response = self.client.get(url)
@@ -35,29 +35,18 @@ class ViewsTests(TestCase):
 
     def test_authenticated_index_view(self):
         # test that when authenticated, it shows index view as expected
-        TestUtils.authenticate_admin(self)
+        TestUtils.authenticate_staff(self)
 
         response = go_to_index(self)
         self.assertContains(response, 'Home')
         self.assertNotContains(response, 'Username')
         self.assertNotContains(response, 'Password')
 
-    def test_no_content_admin(self):
-        TestUtils.authenticate_admin(self)
-
-        response = go_to_index(self)
-        self.assertContains(response, 'No modules are available.')
-        self.assertContains(response, 'No courses are available.')
-        self.assertContains(response, 'No lecturers are available.')
-        self.assertContains(response, 'No students are available.')
-        self.assertContains(response, 'No lectures are available.')
-
     def test_no_content_staff(self):
         TestUtils.authenticate_staff(self)
 
         response = go_to_index(self)
 
-        # shouldn't see mention of 'lecturers'
         self.assertContains(response, 'No modules added.')
         self.assertContains(response, 'No courses added.')
         self.assertNotContains(response, 'No lecturers are available.')
@@ -77,29 +66,6 @@ class ViewsTests(TestCase):
         self.assertNotContains(response, 'No students are available.')
         self.assertContains(response, 'No lectures are available.')
 
-    def test_content_admin(self):
-        TestUtils.authenticate_admin(self)
-        student_1 = TestUtils.create_student('test_student_1')
-        student_2 = TestUtils.create_student('test_student_2')
-        staff_1 = TestUtils.create_staff('test_staff_1')
-        staff_2 = TestUtils.create_staff('test_staff_2')
-        module = TestUtils.create_module('COM101', 'COM101-crn')
-        lecture = create_lecture(module)
-
-        response = go_to_index(self)
-        self.assertNotContains(response, 'No modules are available.')
-        self.assertNotContains(response, 'No courses are available.')
-        self.assertNotContains(response, 'No lecturers are available.')
-        self.assertNotContains(response, 'No students are available.')
-        self.assertNotContains(response, 'No lectures are available.')
-        self.assertContains(response, 'COM101')
-        self.assertContains(response, 'Course Code')
-        self.assertContains(response, 'test_student_1')
-        self.assertContains(response, 'test_student_2')
-        self.assertContains(response, 'test_staff_1')
-        self.assertContains(response, 'test_staff_2')
-        self.assertContains(response, 'Lectures')
-
     def test_content_staff(self):
         test_staff = TestUtils.create_staff('test')
         self.client.login(username='test', password='12345')
@@ -117,6 +83,7 @@ class ViewsTests(TestCase):
         response = go_to_index(self)
         self.assertContains(response, 'No modules added.')
         self.assertContains(response, 'No courses added.')
+        self.assertNotContains(response, 'No lecturers are available.')
         self.assertContains(response, 'No students are available.')
         self.assertContains(response, 'No lectures are available.')
 
@@ -130,6 +97,8 @@ class ViewsTests(TestCase):
         self.assertContains(response, 'COM101')
         self.assertNotContains(response, 'COM999')
         self.assertContains(response, 'Course Code')
+        self.assertContains(response, 'test_staff_1')
+        self.assertContains(response, 'test_staff_2')
         self.assertContains(response, 'test_student_1')
         self.assertNotContains(response, 'test_student_2')
         self.assertContains(response, 'Lectures')

--- a/tool/tests/utils.py
+++ b/tool/tests/utils.py
@@ -5,12 +5,6 @@ from ..models import *
 
 class TestUtils:
     @staticmethod
-    def authenticate_admin(self):
-        user = User.objects.create_superuser(username='test', password='12345', email='test@mail.com')
-        self.client.login(username='test', password='12345')
-        return user
-
-    @staticmethod
     def authenticate_student(self):
         user = TestUtils.create_student('teststudent').user
         self.client.login(username='teststudent', password='12345')

--- a/tool/views/admin_views.py
+++ b/tool/views/admin_views.py
@@ -101,7 +101,7 @@ def check_valid_user(request):
     user_type = ViewsUtils.get_user_type(request)
     ViewsUtils.check_valid_user(user_type, request)
 
-    if not (user_type == UserType.STAFF_TYPE or user_type == UserType.ADMIN_TYPE):
+    if not (user_type == UserType.STAFF_TYPE):
         raise Http404("Not authorised to view this page")
 
 

--- a/tool/views/views_utils.py
+++ b/tool/views/views_utils.py
@@ -8,7 +8,6 @@ from ..models import *
 
 
 class UserType(Enum):
-    ADMIN_TYPE = "ADMIN"
     STAFF_TYPE = "STAFF"
     STUDENT_TYPE = "STUDENT"
 
@@ -27,25 +26,22 @@ class Colours(Enum):
     YELLOW = '#f1c40f'
 
 
-VALID_TYPES = [UserType.ADMIN_TYPE, UserType.STAFF_TYPE, UserType.STUDENT_TYPE]
+VALID_TYPES = [UserType.STAFF_TYPE, UserType.STUDENT_TYPE]
 
 
 class ViewsUtils():
     def get_user_type(request):
-        if request.user.is_staff:
-            return UserType.ADMIN_TYPE
-        else:
-            try:
-                Staff.objects.get(user=request.user)
-                return UserType.STAFF_TYPE
-            except Staff.DoesNotExist:
-                pass
+        try:
+            Staff.objects.get(user=request.user)
+            return UserType.STAFF_TYPE
+        except Staff.DoesNotExist:
+            pass
 
-            try:
-                Student.objects.get(user=request.user)
-                return UserType.STUDENT_TYPE
-            except Student.DoesNotExist:
-                pass
+        try:
+            Student.objects.get(user=request.user)
+            return UserType.STUDENT_TYPE
+        except Student.DoesNotExist:
+            pass
 
         return None
 


### PR DESCRIPTION
Removing 'admin' type from app as it was a Django thing - only staff and students allowed. Any admin-specific permissions migrated to staff, redundant tests removed